### PR TITLE
export composer json file, still ignore lock file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,6 +4,6 @@ vendor/ export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
 .travis.yml export-ignore
-composer.* export-ignore
+composer.lock export-ignore
 phpunit.xml export-ignore
 README.* export-ignore


### PR DESCRIPTION
fixes an issue when you cannot install the module with --prefer-dist