### PR TITLE
Avoid deprecation error in PHP 7.4

### DIFF
--- a/lib/PicoFeed/Client/Url.php
+++ b/lib/PicoFeed/Client/Url.php
@@ -122,7 +122,7 @@ class Url
     {
         $path = $this->getPath();
 
-        return empty($path) || $path{0}
+        return empty($path) || $path[0]
         !== '/';
     }
 


### PR DESCRIPTION
It appears to be the only instance of curly-brace string index usage in the original code.

I have not checked elsewhere in this particular fork, as I'm currently using another fork.