### PR TITLE
Restore most client configuration

### DIFF
--- a/lib/PicoFeed/Client/Client.php
+++ b/lib/PicoFeed/Client/Client.php
@@ -190,6 +190,12 @@ class Client
             'headers' => ['User-Agent' => $this->user_agent],
             'curl' => $this->additional_curl_options,
         ];
+        if (strlen($this->last_modified)) {
+            $opts['headers']['If-Modified-Since'] = $this->last_modified;
+        }
+        if (strlen($this->etag)) {
+            $opts['headers']['If-None-Match'] = $this->etag;
+        }
         if (strlen($this->username)) {
             $opts['auth'] = ['username' => $this->username, 'password' => (string) $this->password];
         }

--- a/lib/PicoFeed/Client/Client.php
+++ b/lib/PicoFeed/Client/Client.php
@@ -126,7 +126,7 @@ class Client
      *
      * @var string
      */
-    protected $user_agent = 'PicoFeed (https://github.com/miniflux/picoFeed)';
+    protected $user_agent = 'PicoFeed (https://github.com/nicolus/picoFeed)';
 
     /**
      * Real URL used (can be changed after a HTTP redirect).

--- a/lib/PicoFeed/Client/Client.php
+++ b/lib/PicoFeed/Client/Client.php
@@ -184,7 +184,29 @@ class Client
      */
     public function doRequest()
     {
-        return $this->httpClient->get($this->url);
+        $opts = [
+            'timeout' => $this->timeout,
+            'allow_redirects' => ['max' => $this->max_redirects],
+            'headers' => ['User-Agent' => $this->user_agent],
+            'curl' => $this->additional_curl_options,
+        ];
+        if (strlen($this->username)) {
+            $opts['auth'] = ['username' => $this->username, 'password' => (string) $this->password];
+        }
+        if (strlen($this->proxy_hostname)) {
+            // Proxies are assumed to be plain HTTP proxies because this is what PicoFeed historically assumed
+            $proxy = "http://";
+            if (strlen($this->proxy_username)) {
+                $proxy .= rawurlencode($this->proxy_username);
+                if (strlen($this->proxy_password)) {
+                    $proxy .= ":" . rawurlencode($this->proxy_password);
+                }
+                $proxy .= "@";
+            }
+            $proxy .= $this->proxy_hostname . ":" . $this->proxy_port;
+            $opts['proxy'] = $proxy; 
+        }
+        return $this->httpClient->get($this->url, $opts);
     }
 
     public function __construct(ClientInterface $httpClient = null)


### PR DESCRIPTION
The switch to Guzzle failed to account for the client options which PicoFeed allowed the user to tweak. This patch restores all but the `maxBodySize` setting, which Guzzle does not have a ready equivalent for.

Though `maxBodySize` could be implemented via stream response handling, I'm not certain if the cache handler supports stream responses (nor am I sure how I would tell if it does), so I'm deferring that for now.