### PR TITLE
Fix favicon finding endless loop

### DIFF
--- a/lib/PicoFeed/Reader/Favicon.php
+++ b/lib/PicoFeed/Reader/Favicon.php
@@ -3,7 +3,7 @@
 namespace PicoFeed\Reader;
 
 use DOMXPath;
-use GuzzleHttp\Exception\BadResponseException;
+use GuzzleHttp\Exception\RequestException;
 use PicoFeed\Base;
 use PicoFeed\Client\Client;
 use PicoFeed\Client\ClientException;
@@ -159,8 +159,8 @@ class Favicon extends Base
                 } elseif ($favicon_link !== '') {
                     return $this->find($website_link);
                 }
-            } catch (\Exception $e) {
-                return $this->find($website_link);
+            } catch (RequestException $e) {
+                continue;
             }
         }
 

--- a/lib/PicoFeed/Reader/Favicon.php
+++ b/lib/PicoFeed/Reader/Favicon.php
@@ -156,15 +156,17 @@ class Favicon extends Base
 
                 if ($this->content !== '') {
                     return $icon_link;
-                } elseif ($favicon_link !== '') {
-                    return $this->find($website_link);
                 }
             } catch (RequestException $e) {
                 continue;
             }
         }
 
-        return '';
+        if ($favicon_link !== '') {
+            return $this->find($website_link);
+        } else {
+            return '';
+        }
     }
 
     /**


### PR DESCRIPTION
I'm not sure what the original intent of the catch-block was, but it's pretty clearly wrong.