### PR TITLE
Plug memory leak

### DIFF
--- a/lib/PicoFeed/Parser/XmlParser.php
+++ b/lib/PicoFeed/Parser/XmlParser.php
@@ -17,7 +17,7 @@ use Laminas\Xml\Security;
  */
 class XmlParser
 {
-    protected $errors = [];
+    protected static $errors = [];
 
     /**
      * Get a SimpleXmlElement instance or return false.
@@ -91,7 +91,7 @@ class XmlParser
             return $dom;
         }
 
-        $this->errors = [];
+        self::$errors = [];
         libxml_use_internal_errors(true);
 
         if (version_compare(PHP_VERSION, '5.4.0', '>=')) {
@@ -101,7 +101,7 @@ class XmlParser
         }
 
         foreach (libxml_get_errors() as $error) {
-            $this->errors[] = sprintf('XML error: %s (Line: %d - Column: %d - Code: %d)',
+            self::$errors[] = sprintf('XML error: %s (Line: %d - Column: %d - Code: %d)',
                 $error->message,
                 $error->line,
                 $error->column,
@@ -136,7 +136,7 @@ class XmlParser
      */
     public static function getErrors()
     {
-        return implode(', ', $this->errors);
+        return implode(', ', self::$errors);
     }
 
     /**

--- a/lib/PicoFeed/Parser/XmlParser.php
+++ b/lib/PicoFeed/Parser/XmlParser.php
@@ -17,6 +17,8 @@ use Laminas\Xml\Security;
  */
 class XmlParser
 {
+    protected $errors = [];
+
     /**
      * Get a SimpleXmlElement instance or return false.
      *
@@ -89,6 +91,7 @@ class XmlParser
             return $dom;
         }
 
+        $this->errors = [];
         libxml_use_internal_errors(true);
 
         if (version_compare(PHP_VERSION, '5.4.0', '>=')) {
@@ -96,6 +99,16 @@ class XmlParser
         } else {
             $dom->loadHTML($input);
         }
+
+        foreach (libxml_get_errors() as $error) {
+            $this->errors[] = sprintf('XML error: %s (Line: %d - Column: %d - Code: %d)',
+                $error->message,
+                $error->line,
+                $error->column,
+                $error->code
+            );
+        }
+        libxml_use_internal_errors(false);
 
         return $dom;
     }
@@ -123,18 +136,7 @@ class XmlParser
      */
     public static function getErrors()
     {
-        $errors = array();
-
-        foreach (libxml_get_errors() as $error) {
-            $errors[] = sprintf('XML error: %s (Line: %d - Column: %d - Code: %d)',
-                $error->message,
-                $error->line,
-                $error->column,
-                $error->code
-            );
-        }
-
-        return implode(', ', $errors);
+        return implode(', ', $this->errors);
     }
 
     /**


### PR DESCRIPTION
This bug existed in Picofeed originally and had been reported by me, but had not been acted upon before the repository was archived and, ultimately, deleted.

When fetching HTML documents Picofeed would buffer libxml's error reports, but then would never clear the buffer. Any subsequent use of document loading with the `DOM` class would thereafter also buffer errors, needlessly consuming memory.