### PR TITLE
Fix unintended API change

### DIFF
--- a/lib/PicoFeed/Client/Client.php
+++ b/lib/PicoFeed/Client/Client.php
@@ -287,8 +287,8 @@ class Client
             $this->is_modified = false;
         } elseif ($response->getStatusCode() == 200) {
             $this->is_modified = $this->hasBeenModified($response, $this->etag, $this->last_modified);
-            $this->etag = $response->getHeader('ETag')[0] ?? null;
-            $this->last_modified = $response->getHeader('Last-Modified')[0] ?? null;
+            $this->etag = $response->getHeader('ETag')[0] ?? '';
+            $this->last_modified = $response->getHeader('Last-Modified')[0] ?? '';
         }
 
         if ($this->is_modified === false) {


### PR DESCRIPTION
`Client::$etag` and `Client::$last_modified` ought always to be strings per their docblocks, but the code sets them to null when not present in the response since commit c69c97a4f6a408051b657233a4c12ad006513b8e.