### PR TITLE
Feedback about 1.0 release

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,0 +1,4 @@
+- maxBodySize setting does nothing
+- API type requirements are not enforced
+- Tests in the "online" group should be rewritten; one is currently broken
+- Use of cache middleware should be documented, or reference from readme removed


### PR DESCRIPTION
As issues are disabled and you have provided no means of contact on GitHub, I am posting this empty pull request as a means of voicing my opinion on a 1.0 release. In my opinion the current state would make for a sub-optimal point for a feature freeze for a few reasons:

## `maxBodySize` setting does nothing

While I have restored most user-facing settings since the change to Guzzle, the `maxBodySize` setting is still non-functional. This should either be implemented, or removed with the removal mentioned in release notes.

## Strict type mode would be helpful

PicoFeed now required PHP 7.1, but it's mostly still a PHP 5 library under the hood. Adding parameter and return type specifications and using strict mode throughout would help avoid problems like happened with #22, and would also help formalize the API.

## Caching is not explained

The readme suggests Guzzle middlewares can be employed for caching, but does not provide any examples or other details. 

## Online tests should be rewritten

The test suite still includes four tests annotated `@group online`, and one of them (`FaviconTest::testDataUri_withBadContentType`) currently fails. These should be rewritten to use synthetic Guzzler responses.

 ---

Please note that I have no desire to do this work myself: I am currently working on my own replacement newsfeed parser, and am only fixing up Picofeed enough for my own purposes in the interim. If you want my opinion, though, you have it. :)