### PR TITLE
PHP 8.2 bugfix when $errors = false in DateParser

### DIFF
--- a/lib/PicoFeed/Parser/DateParser.php
+++ b/lib/PicoFeed/Parser/DateParser.php
@@ -98,7 +98,7 @@ class DateParser extends Base
         if ($date !== false) {
             $errors = DateTime::getLastErrors();
 
-            if (is_array($errors) && $errors['error_count'] === 0 && $errors['warning_count'] === 0) {
+            if ($errors === false || ($errors['error_count'] === 0 && $errors['warning_count'] === 0)) {
                 return $date;
             }
         }

--- a/lib/PicoFeed/Parser/DateParser.php
+++ b/lib/PicoFeed/Parser/DateParser.php
@@ -98,7 +98,7 @@ class DateParser extends Base
         if ($date !== false) {
             $errors = DateTime::getLastErrors();
 
-            if ($errors['error_count'] === 0 && $errors['warning_count'] === 0) {
+            if (is_array($errors) && $errors['error_count'] === 0 && $errors['warning_count'] === 0) {
                 return $date;
             }
         }


### PR DESCRIPTION
I was testing my project with PHP8.2 and ran into the problem where `$errors` in `DateParser.php` was returning `false` due to no errors, but code wasn't taking this boolean result into account and was throwing an Array Offset exception.