### PR TITLE
Fix date parsing error in PHP 8.2

### DIFF
--- a/lib/PicoFeed/Parser/DateParser.php
+++ b/lib/PicoFeed/Parser/DateParser.php
@@ -98,7 +98,7 @@ class DateParser extends Base
         if ($date !== false) {
             $errors = DateTime::getLastErrors();
 
-            if ($errors['error_count'] === 0 && $errors['warning_count'] === 0) {
+            if (!$errors || ($errors['error_count'] === 0 && $errors['warning_count'] === 0)) {
                 return $date;
             }
         }


### PR DESCRIPTION
The same fix was already proposed in #31.