### PR TITLE
Fix deprecation warnings in PHP 8.4

### DIFF
--- a/lib/PicoFeed/Base.php
+++ b/lib/PicoFeed/Base.php
@@ -36,7 +36,7 @@ abstract class Base
      * @param \PicoFeed\Config\Config $config Config class instance
      * @param ClientInterface $httpClient
      */
-    public function __construct(Config $config = null, ClientInterface $httpClient = null)
+    public function __construct(?Config $config = null, ?ClientInterface $httpClient = null)
     {
         $this->config = $config ?: new Config();
         $this->httpClient = $httpClient ?: new Client();

--- a/lib/PicoFeed/Client/Client.php
+++ b/lib/PicoFeed/Client/Client.php
@@ -215,7 +215,7 @@ class Client
         return $this->httpClient->get($this->url, $opts);
     }
 
-    public function __construct(ClientInterface $httpClient = null)
+    public function __construct(?ClientInterface $httpClient = null)
     {
         $this->httpClient = $httpClient;
     }

--- a/lib/PicoFeed/Filter/Html.php
+++ b/lib/PicoFeed/Filter/Html.php
@@ -125,9 +125,8 @@ class Html
 
         $parser = xml_parser_create();
 
-        xml_set_object($parser, $this);
-        xml_set_element_handler($parser, 'startTag', 'endTag');
-        xml_set_character_data_handler($parser, 'dataTag');
+        xml_set_element_handler($parser, [$this, 'startTag'], [$this, 'endTag']);
+        xml_set_character_data_handler($parser, [$this, 'dataTag']);
         xml_parser_set_option($parser, XML_OPTION_CASE_FOLDING, false);
         xml_parse($parser, $this->input, true);
         xml_parser_free($parser);

--- a/lib/PicoFeed/Parser/DateParser.php
+++ b/lib/PicoFeed/Parser/DateParser.php
@@ -98,7 +98,7 @@ class DateParser extends Base
         if ($date !== false) {
             $errors = DateTime::getLastErrors();
 
-            if ($errors['error_count'] === 0 && $errors['warning_count'] === 0) {
+            if (!$errors || ($errors['error_count'] === 0 && $errors['warning_count'] === 0)) {
                 return $date;
             }
         }

--- a/lib/PicoFeed/Parser/Parser.php
+++ b/lib/PicoFeed/Parser/Parser.php
@@ -354,7 +354,7 @@ abstract class Parser implements ParserInterface
      * @param ClientInterface $httpClient
      * @return \PicoFeed\Parser\Parser
      */
-    public function enableContentGrabber($needsRuleFile = false, $scraperCallback = null, ClientInterface $httpClient = null)
+    public function enableContentGrabber($needsRuleFile = false, $scraperCallback = null, ?ClientInterface $httpClient = null)
     {
         $processor = new ScraperProcessor($this->config, $httpClient);
 


### PR DESCRIPTION
PHP 8.4 has deprecated parameters defaulting to null when a non-nullable type hint is used. Such usage was removed by using nullable types. As PHP 7.1 is already required, this has no compatibility implications.

Also included in this patch is my previous patch addressing deprecations in PHP 8.2.